### PR TITLE
Fix pdb resource names

### DIFF
--- a/testing/pdbs/test-pdb01.yaml
+++ b/testing/pdbs/test-pdb01.yaml
@@ -1,9 +1,9 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: test1-pdb
+  name: test-pdb01
 spec:
   minAvailable: 10
   selector:
     matchLabels:
-      app: test1
+      app: test-pdb01

--- a/testing/pdbs/test-pdb02.yaml
+++ b/testing/pdbs/test-pdb02.yaml
@@ -1,9 +1,9 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: test1-pdb
+  name: test-pdb02
 spec:
   minAvailable: "66%"
   selector:
     matchLabels:
-      app: test1
+      app: test-pdb02

--- a/testing/pdbs/test-pdb03.yaml
+++ b/testing/pdbs/test-pdb03.yaml
@@ -1,9 +1,9 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: test1-pdb
+  name: test-pdb03
 spec:
   minAvailable: "67%"
   selector:
     matchLabels:
-      app: test1
+      app: test-pdb03

--- a/testing/pdbs/test-pdb04.yaml
+++ b/testing/pdbs/test-pdb04.yaml
@@ -1,9 +1,9 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: test1-pdb
+  name: test-pdb04
 spec:
   maxUnavailable: 10
   selector:
     matchLabels:
-      app: test1
+      app: test-pdb04

--- a/testing/pdbs/test-pdb05.yaml
+++ b/testing/pdbs/test-pdb05.yaml
@@ -1,9 +1,9 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: test1-pdb
+  name: test-pdb05
 spec:
   maxUnavailable: "33%"
   selector:
     matchLabels:
-      app: test1
+      app: test-pdb05

--- a/testing/pdbs/test-pdb06.yaml
+++ b/testing/pdbs/test-pdb06.yaml
@@ -1,9 +1,9 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: test1-pdb
+  name: test-pdb06
 spec:
   maxUnavailable: "32%"
   selector:
     matchLabels:
-      app: test1
+      app: test-pdb06


### PR DESCRIPTION
This renames the PDB resources used for testing. Previously there was a potential for conflicts in the e2e testing since some shared the same name.