### PR TITLE
Add image build for e2e checks

### DIFF
--- a/.github/workflows/ci-e2e-checks.yaml
+++ b/.github/workflows/ci-e2e-checks.yaml
@@ -52,13 +52,12 @@ jobs:
       timeout-minutes: 5
       run: |
         echo "Loading MagTape images to KinD nodes"
-        man -P cat sed
         GIT_SHA=${{github.sha}}
         kind load docker-image tmobile/magtape-init:sha-${GIT_SHA::7}
         kind load docker-image tmobile/magtape:sha-${GIT_SHA::7}
         echo "Updating target image to use local ref"
-        sed -i -E "s/(MAGTAPE_VERSION := )(.*$)/\1sha-${GIT_SHA::7}/" Makefile
-        sed -i -E 's/(imagePullPolicy:) Always/\1 IfNotPresent/' deploy/manifests/magtape-deploy.yaml
+        sed -i="" -E "s/(MAGTAPE_VERSION := )(.*$)/\1sha-${GIT_SHA::7}/" Makefile
+        sed -i="" -E 's/(imagePullPolicy:) Always/\1 IfNotPresent/' deploy/manifests/magtape-deploy.yaml
         make set-release-version
         make build-single-manifest
         echo "Install MagTape"

--- a/.github/workflows/ci-e2e-checks.yaml
+++ b/.github/workflows/ci-e2e-checks.yaml
@@ -52,14 +52,13 @@ jobs:
       timeout-minutes: 5
       run: |
         echo "Loading MagTape images to KinD nodes"
+        man -P cat sed
         GIT_SHA=${{github.sha}}
         kind load docker-image tmobile/magtape-init:sha-${GIT_SHA::7}
         kind load docker-image tmobile/magtape:sha-${GIT_SHA::7}
         echo "Updating target image to use local ref"
         sed -i -E "s/(MAGTAPE_VERSION := )(.*$)/\1sha-${GIT_SHA::7}/" Makefile
         sed -i -E 's/(imagePullPolicy:) Always/\1 IfNotPresent/' deploy/manifests/magtape-deploy.yaml
-        cat Makefile
-        cat deploy/manifests/magtape-deploy.yaml
         make set-release-version
         make build-single-manifest
         echo "Install MagTape"

--- a/.github/workflows/ci-e2e-checks.yaml
+++ b/.github/workflows/ci-e2e-checks.yaml
@@ -17,6 +17,33 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Check out the repo
+      uses: actions/checkout@v2
+
+    - name: Build magtape-init Container Image
+      if: github.repository == 'tmobile/magtape'
+      timeout-minutes: 10
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        path: ./app/magtape-init/
+        repository: tmobile/magtape-init
+        tag_with_sha: true
+        push: false
+
+    - name: Build magtape Container Image
+      if: github.repository == 'tmobile/magtape'
+      timeout-minutes: 10
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        path: ./app/magtape/
+        repository: tmobile/magtape
+        tag_with_sha: true
+        push: false
+
     - name: Setup KinD Cluster
       timeout-minutes: 5
       uses: engineerd/setup-kind@v0.3.0
@@ -24,12 +51,24 @@ jobs:
     - name: Install MagTape
       timeout-minutes: 5
       run: |
+        echo "Loading MagTape images to KinD nodes"
+        GIT_SHA=${{github.sha}}
+        kind load docker-image tmobile/magtape-init:sha-${GIT_SHA::7}
+        kind load docker-image tmobile/magtape:sha-${GIT_SHA::7}
+        echo "Updating target image to use local ref"
+        sed -i -E "s/(MAGTAPE_VERSION := )(.*$)/\1sha-${GIT_SHA::7}/" Makefile
+        sed -i -E 's/(imagePullPolicy:) Always/\1 IfNotPresent/' deploy/manifests/magtape-deploy.yaml
+        cat Makefile
+        cat deploy/manifests/magtape-deploy.yaml
+        make set-release-version
+        make build-single-manifest
+        echo "Install MagTape"
         make install
         EXPECTED_REPLICAS=$(kubectl get deploy -n magtape-system magtape -o jsonpath='{.status.replicas}')
         READY_REPLICAS=$(kubectl get deploy -n magtape-system magtape -o jsonpath='{.status.readyReplicas}')
         while [ "${READY_REPLICAS}" != "${EXPECTED_REPLICAS}" ]; do
           READY_REPLICAS=$(kubectl get deploy -n magtape-system magtape -o jsonpath='{.status.readyReplicas}')
-          echo "Replicas aren't all ready yet: ${READY_REPLICAS}/${EXPECTED_REPLICAS}"
+          echo "Replicas aren't all ready yet: ${READY_REPLICAS:=0}/${EXPECTED_REPLICAS}"
           sleep 2
         done
 

--- a/Makefile
+++ b/Makefile
@@ -168,10 +168,10 @@ compare-single-manifest:
 .PHONY: set-release-version
 set-release-version:
 
-	sed -i "" "s/\(image: tmobile\/magtape-init:\).*/\1${MAGTAPE_VERSION}/" deploy/manifests/magtape-deploy.yaml
-	sed -i "" "s/\(image: tmobile\/magtape:\).*/\1${MAGTAPE_VERSION}/" deploy/manifests/magtape-deploy.yaml
-	sed -i "" "s/\(image: openpolicyagent\/opa:\).*/\1${OPA_VERSION}/" deploy/manifests/magtape-deploy.yaml
-	sed -i "" "s/\(image: openpolicyagent\/kube-mgmt:\).*/\1${KUBE_MGMT_VERSION}/" deploy/manifests/magtape-deploy.yaml
+	sed -i="" "s/\(image: tmobile\/magtape-init:\).*/\1${MAGTAPE_VERSION}/" deploy/manifests/magtape-deploy.yaml
+	sed -i="" "s/\(image: tmobile\/magtape:\).*/\1${MAGTAPE_VERSION}/" deploy/manifests/magtape-deploy.yaml
+	sed -i="" "s/\(image: openpolicyagent\/opa:\).*/\1${OPA_VERSION}/" deploy/manifests/magtape-deploy.yaml
+	sed -i="" "s/\(image: openpolicyagent\/kube-mgmt:\).*/\1${KUBE_MGMT_VERSION}/" deploy/manifests/magtape-deploy.yaml
 
 ###############################################################################
 # Container Image Targets #####################################################


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/tmobile/magtape/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added and/or ran the appropriate tests for your PR
4. If the PR is unfinished, please mark it as "[WIP]"
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation

/kind feature

**What this PR does / why we need it**:

This adds some additional steps to the e2e checks Github Action workflow to account for PR's that should target updated container images for changes. This adds the ability to build those new images and load them into the KinD cluster without requiring the images to be pushed to DockerHub. This allows changes in the PR to successfully run e2e checks.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #23

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required"
-->

```release-note

```

**Additional documentation e.g., usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
