### PR TITLE
Add GitHub Actions Matrix for Testing multiple K8s versions in e2e Job

### DIFF
--- a/.github/workflows/ci-e2e-checks.yaml
+++ b/.github/workflows/ci-e2e-checks.yaml
@@ -32,6 +32,8 @@ jobs:
           - k8s-version: v1.16
             kind-node-image: kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
 
+    name: e2e-tests for K8s ${{ matrix.k8s-version }}
+
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/ci-e2e-checks.yaml
+++ b/.github/workflows/ci-e2e-checks.yaml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - master
+      - ci-k8s-matrix
   push:
     branches:
       - master
+      - ci-k8s-matrix
 
 # Jobs
 jobs:
@@ -67,7 +69,7 @@ jobs:
           version: "v0.9.0"
           image: ${{ matrix.kind-node-image }}
 
-    - name: Install MagTape on K8s
+    - name: Install MagTape
       timeout-minutes: 5
       run: |
         echo "Loading MagTape images to KinD nodes"
@@ -94,7 +96,7 @@ jobs:
       run: |
         make ns-create-test
 
-    - name: Install tools 
+    - name: Install Tools 
       timeout-minutes: 5
       run: |
         sudo add-apt-repository ppa:rmescandon/yq

--- a/.github/workflows/ci-e2e-checks.yaml
+++ b/.github/workflows/ci-e2e-checks.yaml
@@ -13,6 +13,22 @@ jobs:
   # Job to lint code
   e2e-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        k8s-version:
+          - v1.19
+          - v1.18
+          - v1.17
+          - v1.16
+        include:
+          - k8s-version: v1.19
+            kind-node-image: kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
+          - k8s-version: v1.18
+            kind-node-image: kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb
+          - k8s-version: v1.17
+            kind-node-image: kindest/node:v1.17.11@sha256:5240a7a2c34bf241afb54ac05669f8a46661912eab05705d660971eeb12f6555
+          - k8s-version: v1.16
+            kind-node-image: kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
 
     steps:
     - uses: actions/checkout@v2
@@ -48,9 +64,10 @@ jobs:
       timeout-minutes: 5
       uses: engineerd/setup-kind@v0.4.0
       with:
-          version: "v0.8.1"
+          version: "v0.9.0"
+          image: ${{ matrix.kind-node-image }}
 
-    - name: Install MagTape
+    - name: Install MagTape on K8s
       timeout-minutes: 5
       run: |
         echo "Loading MagTape images to KinD nodes"
@@ -77,7 +94,7 @@ jobs:
       run: |
         make ns-create-test
 
-    - name: Install tools
+    - name: Install tools 
       timeout-minutes: 5
       run: |
         sudo add-apt-repository ppa:rmescandon/yq

--- a/.github/workflows/ci-e2e-checks.yaml
+++ b/.github/workflows/ci-e2e-checks.yaml
@@ -4,11 +4,9 @@ on:
   pull_request:
     branches:
       - master
-      - ci-k8s-matrix
   push:
     branches:
       - master
-      - ci-k8s-matrix
 
 # Jobs
 jobs:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/tmobile/magtape/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added and/or ran the appropriate tests for your PR
4. If the PR is unfinished, please mark it as "[WIP]"
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation

/kind feature

**What this PR does / why we need it**:

This adds a GitHub Actions matrix for running the e2e tests against multiple versions of Kubernetes. It specifies a short `k8s-versions` variable and a longer `kind-node-image` variable that references explicit kind node image tags to target specific k8s versions in CI.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #32

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required"
-->

```release-note
NONE
```

**Additional documentation e.g., usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
