### PR TITLE
Surface server-side warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,3 +62,27 @@ This release focuses on some security enhancements.
 ### Misc Notes
 
 - Changes OPA container listening port from `443` to `8443` since a non-root user can't bind to ports below 1000. The OPA container isn't exposed outside of localhost, so this shouldn't present any issues
+
+## 2.3.0
+
+This release brings some new features, CI enhancements, changes to test mocking, and some updates to documentation.
+
+### Enhancements
+
+- Enable shellcheck linting for bash (#57 authored by @ilrudie)
+- Cleanup Rego testing/mocking (#60)
+- Update docker/build-push-action to v2 (#62 authored by @ilrudie)
+- Update functional testing documentation (#65 authored by @ilrudie)
+- Enable server-side warnings on policy failures ()
+
+**server-side warnings on policy failures**
+
+Server-side warnings were added in Kubernetes v1.19. This enhancement allows for messages to be surfaced to the end-users via kubectl and client-go. This gives MagTape yet another mechanism to display feedback on policy failures to the end-user. This change is transparent for Kubernetes releases prior to v1.19.
+
+- [Kubernetes Blog](https://kubernetes.io/blog/2020/09/03/warnings/#admission-webhooks)
+- [Kubernetes Enhancement Proposal](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1693-warnings#server-side)
+- [Changes to Admission Response Struct](https://github.com/kubernetes/kubernetes/blob/f7a13de36c4584464adc991c7a3d1f38f610232e/pkg/apis/admission/types.go#L141)
+
+**Version 2 for docker/build-push-action**
+
+Adopting version 2 of this action allows us to start consuming Docker `buildx`. This is transparent at the moment, but should allow us to more easily build images for e2e checks and relases across multiple architectures (amd64, ARM, ppc64le, etc.).

--- a/app/magtape/magtape.py
+++ b/app/magtape/magtape.py
@@ -135,7 +135,7 @@ def magtape(request_spec):
     """main function"""
 
     # Zero out specific info per call
-    allowed = True
+    is_allowed = True
     skip_alert = False
     response_message = ""
     alert_should_send = False
@@ -196,12 +196,12 @@ def magtape(request_spec):
 
     app.logger.debug(f"Skip Alert: {skip_alert}")
 
-    # Set allowed value based on DENY_LEVEL and response_message content
+    # Set is_allowed value based on DENY_LEVEL and response_message content
     if magtape_deny_level == "OFF":
 
         app.logger.debug("Deny level detected: OFF")
 
-        allowed = True
+        is_allowed = True
 
     elif magtape_deny_level == "LOW":
 
@@ -213,7 +213,7 @@ def magtape(request_spec):
 
             app.logger.debug("Sev Fail level: HIGH")
 
-            allowed = False
+            is_allowed = False
             alert_should_send = True
 
     elif magtape_deny_level == "MED":
@@ -226,7 +226,7 @@ def magtape(request_spec):
 
             app.logger.debug("Sev Fail level: HIGH/MED")
 
-            allowed = False
+            is_allowed = False
             alert_should_send = True
 
     elif magtape_deny_level == "HIGH":
@@ -239,26 +239,31 @@ def magtape(request_spec):
 
             app.logger.debug("Sev Fail level: HIGH/MED/LOW")
 
-            allowed = False
+            is_allowed = False
             alert_should_send = True
 
     else:
 
         app.logger.debug("Deny level detected: NONE")
 
-        allowed = False
+        is_allowed = False
         alert_should_send = True
 
-    # Set optional message if allowed = false
-    if allowed:
+    # Set optional message if is_allowed = false
+    if is_allowed:
 
-        admission_response = {"allowed": allowed}
+        admission_response = {
+            "uid": uid,
+            "allowed": is_allowed,
+            "warnings": response_message.split(", "),
+        }
 
     else:
 
         admission_response = {
             "uid": uid,
-            "allowed": allowed,
+            "allowed": is_allowed,
+            "warnings": response_message.split(", "),
             "status": {"message": response_message},
         }
 
@@ -318,11 +323,11 @@ def magtape(request_spec):
                     request_user,
                     customer_alert_sent,
                     magtape_deny_level,
-                    allowed,
+                    is_allowed,
                 )
 
             # Increment Prometheus Counters
-            if allowed:
+            if is_allowed:
 
                 magtape_metrics_requests.labels(
                     count_type="allowed", ns=namespace, alert_sent="true"
@@ -345,7 +350,7 @@ def magtape(request_spec):
         app.logger.info(f"Slack alerts are NOT enabled")
 
         # Increment Prometheus Counters
-        if allowed:
+        if is_allowed:
 
             magtape_metrics_requests.labels(
                 count_type="allowed", ns=namespace, alert_sent="false"
@@ -631,7 +636,7 @@ def send_slack_alert(
     request_user,
     customer_alert_sent,
     magtape_deny_level,
-    allowed,
+    is_allowed,
 ):
 
     """Function to format and send Slack alert for policy failures"""
@@ -640,7 +645,7 @@ def send_slack_alert(
     alert_header = "MagTape | Policy Denial Detected"
     alert_color = "danger"
 
-    if allowed:
+    if is_allowed:
 
         alert_header = "MagTape | Policy Failures Detected"
         alert_color = "warning"

--- a/app/magtape/magtape.py
+++ b/app/magtape/magtape.py
@@ -369,7 +369,11 @@ def magtape(request_spec):
             ).inc()
 
     # Build Admission Response
-    admissionReview = {"response": admission_response}
+    admissionReview = {
+        "apiVersion": "admission.k8s.io/v1beta1",
+        "kind": "AdmissionReview",
+        "response": admission_response,
+    }
 
     app.logger.info("Sending Response to K8s API Server")
     app.logger.debug(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/tmobile/magtape/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added and/or ran the appropriate tests for your PR
4. If the PR is unfinished, please mark it as "[WIP]"
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation

/kind feature

**What this PR does / why we need it**:

This PR adds the new "warnings" field to the Admission Response generated by the MagTape Admission Webhook. This is a new feature added in Kubernetes 1.19.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #63 

**Special notes for your reviewer**:

NA

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required"
-->

```release-note
Server-side warnings were added in Kubernetes v1.19. This enhancement allows for messages to be surfaced to the end-users via kubectl and client-go. This gives MagTape yet another mechanism to display feedback on policy failures to the end-user. This change is transparent for Kubernetes releases prior to v1.19.

- [Kubernetes Blog](https://kubernetes.io/blog/2020/09/03/warnings/#admission-webhooks)
- [Kubernetes Enhancement Proposal](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1693-warnings#server-side)
- [Changes to Admission Response Struct](https://github.com/kubernetes/kubernetes/blob/f7a13de36c4584464adc991c7a3d1f38f610232e/pkg/apis/admission/types.go#L141)
```

**Additional documentation e.g., usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
