### PR TITLE
Bump kind node images to latest

### DIFF
--- a/.github/workflows/ci-e2e-checks.yaml
+++ b/.github/workflows/ci-e2e-checks.yaml
@@ -20,14 +20,14 @@ jobs:
           - v1.17
           - v1.16
         include:
+          - k8s-version: v1.20
+            kind-node-image: kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
           - k8s-version: v1.19
-            kind-node-image: kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
+            kind-node-image: kindest/node:v1.19.7@sha256:a70639454e97a4b733f9d9b67e12c01f6b0297449d5b9cbbef87473458e26dca
           - k8s-version: v1.18
-            kind-node-image: kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb
+            kind-node-image: kindest/node:v1.18.15@sha256:5c1b980c4d0e0e8e7eb9f36f7df525d079a96169c8a8f20d8bd108c0d0889cc4
           - k8s-version: v1.17
-            kind-node-image: kindest/node:v1.17.11@sha256:5240a7a2c34bf241afb54ac05669f8a46661912eab05705d660971eeb12f6555
-          - k8s-version: v1.16
-            kind-node-image: kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
+            kind-node-image: kindest/node:v1.17.17@sha256:7b6369d27eee99c7a85c48ffd60e11412dc3f373658bc59b7f4d530b7056823e
 
     name: e2e-tests for K8s ${{ matrix.k8s-version }}
 

--- a/.github/workflows/ci-e2e-checks.yaml
+++ b/.github/workflows/ci-e2e-checks.yaml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       matrix:
         k8s-version:
+          - v1.20
           - v1.19
           - v1.18
           - v1.17
-          - v1.16
         include:
           - k8s-version: v1.20
             kind-node-image: kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/tmobile/magtape/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added and/or ran the appropriate tests for your PR
4. If the PR is unfinished, please mark it as "[WIP]"
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug

/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind feature

**What this PR does / why we need it**:

This PR moves our end-to-end CI workflow to use the KinD node Images.

Testing for k8s v1.20 is added and v1.16 is removed. The k8s v1.17, 1.18, and v1.19 images are all bumped to the latest supported fix release.

```yaml
- k8s-version: v1.20
   kind-node-image: kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
- k8s-version: v1.19
   kind-node-image: kindest/node:v1.19.7@sha256:a70639454e97a4b733f9d9b67e12c01f6b0297449d5b9cbbef87473458e26dca
- k8s-version: v1.18
   kind-node-image: kindest/node:v1.18.15@sha256:5c1b980c4d0e0e8e7eb9f36f7df525d079a96169c8a8f20d8bd108c0d0889cc4
- k8s-version: v1.17
   kind-node-image: kindest/node:v1.17.17@sha256:7b6369d27eee99c7a85c48ffd60e11412dc3f373658bc59b7f4d530b7056823e
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #76 

**Special notes for your reviewer**:

Once this is merged we will need to remove the 1.16 versioned e2e check from being required and add the 1.20 check as required.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required"
-->

```release-note
NONE
```

**Additional documentation e.g., usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
