### PR TITLE
Add multi-arch config for buildx action

### DIFF
--- a/.github/workflows/ci-image-build.yaml
+++ b/.github/workflows/ci-image-build.yaml
@@ -5,7 +5,12 @@ on:
     # Dynamic releasetag tag is set based on the assumption this ci task only runs on release
     types: [published]
 
+# Variables to be used throughout the workflow manifest
+env:
+  TARGET_PLATFORMS: linux/amd64,linux/arm64,linux/ppc64le
+
 jobs:
+
   # Build and push magtape-init container image
   build-magtape-init-image:
     name: Build and push magtape-init images to DockerHub
@@ -22,6 +27,10 @@ jobs:
         # GITHUB_REF variable must exist in action; this may rely on {{ on: release: types: [published] }} gating the action
         run: |
           echo ::set-output name=releasetag::${GITHUB_REF#refs/tags/}
+
+      # Setup QEMU to support multi-arch builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
           
       # Part of docker/build-push-action@v2; setting up the build system
       - name: Set up Docker Buildx
@@ -36,12 +45,14 @@ jobs:
 
       - name: Build and push magtape-init image to DockerHub
         if: github.repository == 'tmobile/magtape'
-        timeout-minutes: 10
+        timeout-minutes: 30
         uses: docker/build-push-action@v2
         with:
           context: ./app/magtape-init/
           # file should be specified relative to the repo root rather than relative to the context
           file: ./app/magtape-init/Dockerfile
+          # Defines the target platform architectures images should be built for
+          platforms: ${{ env.TARGET_PLATFORMS }}
           # push is no longer defaulted to true under v2; to push you must specify push is true
           push: true
           # Uses the releasetag output exposed by the Collect Release Tag step to set the tag under v2
@@ -64,6 +75,10 @@ jobs:
         run: |
           echo ::set-output name=releasetag::${GITHUB_REF#refs/tags/}
 
+      # Setup QEMU to support multi-arch builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       # Part of docker/build-push-action@v2; setting up the build system
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -77,12 +92,14 @@ jobs:
 
       - name: Build and push magtape image to DockerHub
         if: github.repository == 'tmobile/magtape'
-        timeout-minutes: 10
+        timeout-minutes: 30
         uses: docker/build-push-action@v2
         with:
           context: ./app/magtape/
           # file should be specified relative to the repo root rather than relative to the context
           file: ./app/magtape/Dockerfile
+          # Defines the target platform architectures images should be built for
+          platforms: ${{ env.TARGET_PLATFORMS }}
           # push is no longer defaulted to true under v2; to push you must specify push is true
           push: true
           # Uses the releasetag output exposed by the Collect Release Tag step to set the tag under v2

--- a/docs/release.md
+++ b/docs/release.md
@@ -75,6 +75,14 @@ CHANGELOG.md snippet.
 
 	NOTE: You may have to adjust the Markdown Headers (ie. `#`) since the Headers for a specific release in the CHANGELOG.md file are not top level (ie. They start with `##` instead of `#`)
 
-## Notes
+## Container Images
 
-- The tmobile/magtape-init and tmobile/magtape Docker images are automatically built and published to Docker Hub when a release is created. There are no manual steps involved here.
+The `tmobile/magtape-init` and `tmobile/magtape` Docker images are automatically built and published to Docker Hub when a release is created. 
+
+Images are published for the following platforms:
+
+- linux/amd64
+- linux/arm64
+- linux/ppc64le
+
+There are no manual steps involved here.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/tmobile/magtape/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added and/or ran the appropriate tests for your PR
4. If the PR is unfinished, please mark it as "[WIP]"
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
/kind feature
> /kind release

**What this PR does / why we need it**:

This PR adds required configuration to produce container image builds for multiple platform architectures. This allows for MgTape to operate on other hardware types. With this change, the release workflow will produce image builds for the following platform architectures:

- linux/amd64
- linux/arm64
- linux/ppc64le

This PR also extends the timeout values for the build/push actions as the time for builds increases with each added architecture. Release documentation was also updated to list the current targeted platform architectures.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #106 

**Special notes for your reviewer**:

NA

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required"
-->

```release-note
NONE
```

**Additional documentation e.g., usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
